### PR TITLE
Ship worker metrics to Grafana via OTEL Collector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ start-native-worker: ## Starts Native Temporal worker
 	cd applications/worker; poetry run temporal-worker
 
 start-docker-worker: ## Starts Temporal worker in docker
-	docker compose up worker
+	docker compose up worker worker-otel-collector
 
 start-all-detached: ## Starts all docker containers in detached mode
 	docker compose up -d

--- a/applications/otel-collector/Dockerfile
+++ b/applications/otel-collector/Dockerfile
@@ -22,6 +22,3 @@ RUN /bin/sh ./generate-otel-config.sh "/config"
 FROM otel/opentelemetry-collector-contrib:latest AS release
 
 COPY --from=build /config/*.yaml .
-
-# Run the collector
-CMD ["--feature-gates=-component.UseLocalHostAsDefaultHost"]

--- a/applications/otel-collector/Dockerfile
+++ b/applications/otel-collector/Dockerfile
@@ -19,6 +19,6 @@ COPY generate-otel-config.sh generate-otel-config.sh
 RUN /bin/sh ./generate-otel-config.sh "/config"
 
 # Start release stage and Copy all generated configuration files in
-FROM otel/opentelemetry-collector-contrib:latest AS release
+FROM otel/opentelemetry-collector-contrib:0.109.0 AS release
 
 COPY --from=build /config/*.yaml .

--- a/applications/otel-collector/generate-otel-config.sh
+++ b/applications/otel-collector/generate-otel-config.sh
@@ -38,7 +38,7 @@ write_file() {
 }
 
 template_src=${OTEL_APP_DIR}/otel-template.yaml
-docker_server_dest=${OTEL_APP_DIR}/otel-server-config-docker.yaml
 
 
-write_file ${template_src} ${docker_server_dest} "temporal-server:4333"
+write_file ${template_src} "${OTEL_APP_DIR}/otel-server-config-docker.yaml" "temporal-server:4333"
+write_file ${template_src} "${OTEL_APP_DIR}/otel-worker-config-docker.yaml" "worker:9000"

--- a/applications/otel-collector/otel-template.yaml
+++ b/applications/otel-collector/otel-template.yaml
@@ -24,7 +24,7 @@ receivers:
         #       regex: '.*grpc_io.*'
         #       action: drop
         - job_name: 'temporalcol'
-          scrape_interval: 10s
+          scrape_interval: 60s
           static_configs:
             - targets: ["$OTEL_SCRAPE_TARGET"]
           metrics_path: "/metrics"
@@ -42,10 +42,10 @@ exporters:
 service:
   extensions: [basicauth/otlp]
 
-  telemetry:
-    metrics:
-      address: 0.0.0.0:8888
-      level: detailed
+  # telemetry:
+  #   metrics:
+  #     address: 0.0.0.0:8888
+  #     level: detailed
   pipelines:
     metrics:
       receivers: [prometheus]

--- a/applications/worker/worker/config/config.py
+++ b/applications/worker/worker/config/config.py
@@ -25,3 +25,9 @@ class TemporalConfig(BaseConfig):
 
     def get_server_port(self) -> str:
         return self.temporal_config['server']['port']
+
+    def is_metrics_enabled(self) -> bool:
+        return self.temporal_config['metrics']['enabled']
+
+    def get_metrics_bind_address(self) -> str:
+        return self.temporal_config['metrics']['bind_address']

--- a/applications/worker/worker/config/docker.yaml
+++ b/applications/worker/worker/config/docker.yaml
@@ -1,3 +1,7 @@
+# Yaml Configuration file defines default configuration for several configurable
+# values that the application utilizes. There is one for each environment that this
+# application can be deployed to
+# The relevant config file should be set be defining the PYYAML_CONFIG environment variable
 
 temporal:
 
@@ -8,3 +12,9 @@ temporal:
 
     # Port Name of temporal server/frontend Gateway
     port: 7233
+
+
+  metrics:
+    # Enable Prometheus metrics endpoint
+    enabled: true
+    bind_address: '0.0.0.0:9000'

--- a/applications/worker/worker/config/local.yaml
+++ b/applications/worker/worker/config/local.yaml
@@ -3,8 +3,6 @@
 # application can be deployed to
 # The relevant config file should be set be defining the PYYAML_CONFIG environment variable
 
-# Additionally each value in the configuration file can be overriden by environment values when
-# necessary
 temporal:
 
   # Temporal Server Connection Settings
@@ -14,3 +12,8 @@ temporal:
 
     # Port Name of temporal server/frontend Gateway
     port: 7233
+
+  metrics:
+    # Enable Prometheus metrics endpoint
+    enabled: false
+    bind_address: '0.0.0.0:9000'

--- a/applications/worker/worker/main.py
+++ b/applications/worker/worker/main.py
@@ -3,6 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 import multiprocessing
 
+from worker.temporal_client import get_temporal_client
 from worker.config.config import TemporalConfig
 from temporalio import activity, workflow
 from temporalio.client import Client
@@ -33,12 +34,7 @@ async def say_hello_activity(name: str) -> str:
 async def run_worker():
     print('start worker')
 
-    temporal_config = TemporalConfig()
-    temporal_url = f"{temporal_config.get_server_host()}:{temporal_config.get_server_port()}"
-    print(f"Connecting to {temporal_url} ...")
-
-    client = await Client.connect(temporal_url)
-    print('connected')
+    client = await get_temporal_client()
 
     worker = Worker(
         client,

--- a/applications/worker/worker/temporal_client.py
+++ b/applications/worker/worker/temporal_client.py
@@ -1,0 +1,26 @@
+from temporalio.client import Client
+from worker.config.config import TemporalConfig
+from temporalio.runtime import Runtime, TelemetryConfig, PrometheusConfig
+
+
+async def get_temporal_client():
+    temporal_config = TemporalConfig()
+
+    if temporal_config.is_metrics_enabled():
+        address = temporal_config.get_metrics_bind_address()
+        print(f'Metrics Enabled on {address}')
+        runtime = Runtime(
+            telemetry=TelemetryConfig(
+                metrics=PrometheusConfig(
+                    bind_address=address
+                )
+            )
+        )
+    else:
+        runtime = None
+
+    temporal_url = f"{temporal_config.get_server_host()}:{temporal_config.get_server_port()}"
+    print(f"Connecting to {temporal_url} ...")
+    client = await Client.connect(temporal_url, runtime=runtime)
+    print('connected')
+    return client

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,8 @@ services:
       context: applications/worker
     environment:
       - PYYAML_CONFIG=worker/config/docker.yaml
+    ports:
+      - 9000:9000 # expose prometheus metrics endpoint
     depends_on:
       - temporal-server
     networks:
@@ -92,8 +94,30 @@ services:
       - temporal-network
 
   # OTEL Collector for metrics emitted from temporal-server
-  server-otel-collector:
-    container_name: server-otel-collector
+  # server-otel-collector:
+  #   container_name: server-otel-collector
+  #   build:
+  #     context: applications/otel-collector
+  #     args:
+  #       - OTEL_GRAFANA_INSTANCE_ID=${OTEL_GRAFANA_INSTANCE_ID}
+  #       - OTEL_GRAFANA_API_TOKEN=${OTEL_GRAFANA_API_TOKEN}
+  #       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT}
+  #   environment:
+  #     - OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
+  #     - OTEL_EXPORTER_OTLP_HEADERS=${OTEL_EXPORTER_OTLP_HEADERS}
+  #   command:
+  #     - --config=otel-server-config-docker.yaml
+  #   ports:
+  #     - 4317:4317
+  #     - 8888:8888
+  #   depends_on:
+  #     - temporal-server
+  #   networks:
+  #     - temporal-network
+
+# OTEL Collector for metrics emitted from the worker
+  worker-otel-collector:
+    container_name: worker-otel-collector
     build:
       context: applications/otel-collector
       args:
@@ -104,12 +128,10 @@ services:
       - OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
       - OTEL_EXPORTER_OTLP_HEADERS=${OTEL_EXPORTER_OTLP_HEADERS}
     command:
-      - --config=otel-server-config-docker.yaml
-    ports:
-      - 4317:4317
-      - 8888:8888
+      - --config=otel-worker-config-docker.yaml
+      - --feature-gates=-component.UseLocalHostAsDefaultHost
     depends_on:
-      - temporal-server
+      - worker
     networks:
       - temporal-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,26 +94,24 @@ services:
       - temporal-network
 
   # OTEL Collector for metrics emitted from temporal-server
-  # server-otel-collector:
-  #   container_name: server-otel-collector
-  #   build:
-  #     context: applications/otel-collector
-  #     args:
-  #       - OTEL_GRAFANA_INSTANCE_ID=${OTEL_GRAFANA_INSTANCE_ID}
-  #       - OTEL_GRAFANA_API_TOKEN=${OTEL_GRAFANA_API_TOKEN}
-  #       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT}
-  #   environment:
-  #     - OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
-  #     - OTEL_EXPORTER_OTLP_HEADERS=${OTEL_EXPORTER_OTLP_HEADERS}
-  #   command:
-  #     - --config=otel-server-config-docker.yaml
-  #   ports:
-  #     - 4317:4317
-  #     - 8888:8888
-  #   depends_on:
-  #     - temporal-server
-  #   networks:
-  #     - temporal-network
+  server-otel-collector:
+    container_name: server-otel-collector
+    build:
+      context: applications/otel-collector
+      args:
+        - OTEL_GRAFANA_INSTANCE_ID=${OTEL_GRAFANA_INSTANCE_ID}
+        - OTEL_GRAFANA_API_TOKEN=${OTEL_GRAFANA_API_TOKEN}
+        - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT}
+    environment:
+      - OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
+      - OTEL_EXPORTER_OTLP_HEADERS=${OTEL_EXPORTER_OTLP_HEADERS}
+    command:
+      - --config=otel-server-config-docker.yaml
+      - --feature-gates=-component.UseLocalHostAsDefaultHost
+    depends_on:
+      - temporal-server
+    networks:
+      - temporal-network
 
 # OTEL Collector for metrics emitted from the worker
   worker-otel-collector:


### PR DESCRIPTION
### Changes

- Configures Prometheus metrics for worker
- Generates configuration for worker otel collector
- Adds docker-compose entry for worker otel collector

### Context

The temporalio SDK supports shipping worker metrics via prometheus, so this PR shows an example of configuring that in python.

In order to ship those metrics to Grafana we are also using the otel-collector to scrape the metrics from the worker and send them to grafana